### PR TITLE
feat(auth): add resend verification email endpoint with rate limiting; block login for unverified users

### DIFF
--- a/auth/controllers.py
+++ b/auth/controllers.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from flask import current_app
+from flask import current_app, jsonify
 from flask_jwt_extended import create_access_token, create_refresh_token, get_jwt_identity
 from sqlalchemy.exc import IntegrityError
 from authlib.integrations.flask_client import OAuth
@@ -7,7 +7,7 @@ from authlib.integrations.flask_client import OAuth
 from common.database import db
 from auth.models import User, MerchantProfile, RefreshToken, EmailVerification, UserRole, AuthProvider
 from auth.utils import validate_google_token
-from common.cache import cached
+from common.cache import cached, get_redis_client
 from auth.email_utils import send_verification_email, send_password_reset_email
 
 # Initialize OAuth
@@ -119,69 +119,37 @@ def login_user(data):
     try:
         login_email = data['email']
         password = data['password']
-        
-        # Check if this is a business email login
-        if 'business_email' in data:
-            # First check if this is a merchant's business email
-            merchant = MerchantProfile.query.filter_by(business_email=login_email).first()
-            if merchant:
-                # Get the associated user account
-                user = User.get_by_id(merchant.user_id)
-                if not user or not user.check_password(password):
-                    return {"error": "Invalid business email or password"}, 401
-                
-                if not user.is_active:
-                    return {"error": "Account is disabled"}, 403
-                
-                # Update last login timestamp
-                user.update_last_login()
-                
-                # Generate tokens
-                access_token = create_access_token(identity=str(user.id))
-                access_token = create_access_token(identity=str(user.id))                
-                refresh_expires = datetime.utcnow() + current_app.config['JWT_REFRESH_TOKEN_EXPIRES']
-                refresh_token = RefreshToken.create_token(user.id, refresh_expires)
-                
-                return {
-                    "message": "Merchant login successful",
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                    "user": {
-                        "id": user.id,
-                        "email": user.email,
-                        "first_name": user.first_name,
-                        "last_name": user.last_name,
-                        "role": user.role.value
-                    }
-                }, 200
-        
-        # Regular user login with email
-        user = User.get_by_email(login_email)
-        if not user or not user.check_password(password):
+        is_business_login = 'business_email' in data and data['business_email'] is True
+        user_to_check = None
+        if is_business_login:
+            merchant_profile = MerchantProfile.query.filter_by(business_email=login_email).first()
+            if merchant_profile:
+                user_to_check = User.get_by_id(merchant_profile.user_id)
+        else:
+            user_to_check = User.get_by_email(login_email)
+        if not user_to_check or not user_to_check.check_password(password):
             return {"error": "Invalid email or password"}, 401
-        
-        if not user.is_active:
+        if not user_to_check.is_active:
             return {"error": "Account is disabled"}, 403
-        
-        # Update last login timestamp
-        user.update_last_login()
-        
-        # Generate tokens
-        access_token = create_access_token(identity=str(user.id))
-        access_token = create_access_token(identity=str(user.id))        
+        # Email verification check
+        if not user_to_check.is_email_verified:
+            return {"error_code": "EMAIL_NOT_VERIFIED", "message": "Please verify your email address to log in.", "email": user_to_check.email}, 403
+        user_to_check.update_last_login()
+        additional_claims = {"role": user_to_check.role.value}
+        access_token = create_access_token(identity=str(user_to_check.id), additional_claims=additional_claims)
         refresh_expires = datetime.utcnow() + current_app.config['JWT_REFRESH_TOKEN_EXPIRES']
-        refresh_token = RefreshToken.create_token(user.id, refresh_expires)
-        
+        refresh_token_str = RefreshToken.create_token(user_to_check.id, refresh_expires)
+        login_message = "Merchant login successful" if is_business_login and user_to_check.role == UserRole.MERCHANT else "Login successful"
         return {
-            "message": "Login successful",
+            "message": login_message,
             "access_token": access_token,
-            "refresh_token": refresh_token,
+            "refresh_token": refresh_token_str,
             "user": {
-                "id": user.id,
-                "email": user.email,
-                "first_name": user.first_name,
-                "last_name": user.last_name,
-                "role": user.role.value
+                "id": user_to_check.id,
+                "email": user_to_check.email,
+                "first_name": user_to_check.first_name,
+                "last_name": user_to_check.last_name,
+                "role": user_to_check.role.value
             }
         }, 200
     except Exception as e:
@@ -427,3 +395,72 @@ def reset_password(token, new_password):
         db.session.rollback()
         current_app.logger.error(f"Password reset error: {str(e)}")
         return {"error": "Failed to reset password"}, 500
+    
+def resend_verification_email_controller(email_address):
+    """Handles resending of verification email with rate limiting."""
+    try:
+        user = User.get_by_email(email_address)
+        if not user:
+            return {"message": "If your email is registered and not verified, a new verification link has been sent."}, 200
+        if user.role == UserRole.SUPER_ADMIN:
+            return {"message": "This action is not applicable for super administrators."}, 200
+        if user.is_email_verified:
+            return {"message": "Your email address is already verified."}, 200
+        redis_client = get_redis_client(current_app)
+        if not redis_client:
+            current_app.logger.error("Redis client not available for rate limiting resend verification email.")
+        attempts_key = f"rate_limit:resend_verify_email_attempts:{email_address}"
+        last_attempt_ts_key = f"rate_limit:resend_verify_email_last_ts:{email_address}"
+        last_attempt_date_key = f"rate_limit:resend_verify_email_last_date:{email_address}"
+        pipe = redis_client.pipeline()
+        pipe.get(attempts_key)
+        pipe.get(last_attempt_ts_key)
+        pipe.get(last_attempt_date_key)
+        attempts_raw, last_attempt_ts_raw, last_attempt_date_raw = pipe.execute()
+        attempts = int(attempts_raw) if attempts_raw else 0
+        last_attempt_ts = float(last_attempt_ts_raw) if last_attempt_ts_raw else 0
+        last_attempt_date_str = last_attempt_date_raw.decode('utf-8') if last_attempt_date_raw else None
+        current_time_utc = datetime.utcnow()
+        current_timestamp = current_time_utc.timestamp()
+        current_date_str = current_time_utc.date().isoformat()
+        if last_attempt_date_str != current_date_str:
+            attempts = 0
+            pipe = redis_client.pipeline()
+            pipe.set(attempts_key, 0)
+            pipe.set(last_attempt_date_key, current_date_str)
+            pipe.expire(attempts_key, 86400 * 2)
+            pipe.expire(last_attempt_date_key, 86400 * 2)
+            pipe.expire(last_attempt_ts_key, 86400 * 2)
+            pipe.execute()
+        rate_limit_tiers = [ (0, 0), (1, 30), (2, 60), (3, 60) ]
+        max_attempts_per_day = 4
+        if attempts >= max_attempts_per_day:
+            tomorrow_utc = current_time_utc.date() + timedelta(days=1)
+            next_day_start_utc = datetime.combine(tomorrow_utc, datetime.min.time(), tzinfo=timezone.utc)
+            retry_after = (next_day_start_utc - current_time_utc).total_seconds()
+            return {"error_code": "RATE_LIMIT_EXCEEDED", "message": "You have reached the maximum number of resend attempts for today.", "retry_after": int(retry_after)}, 429
+        current_tier_delay = rate_limit_tiers[attempts][1] if attempts < len(rate_limit_tiers) else rate_limit_tiers[-1][1]
+        if last_attempt_ts > 0 and (current_timestamp - last_attempt_ts < current_tier_delay):
+            retry_after_seconds = current_tier_delay - (current_timestamp - last_attempt_ts)
+            return {"error_code": "RATE_LIMIT_APPLIED", "message": "Please wait before trying again.", "retry_after": int(retry_after_seconds) + 1}, 429
+        EmailVerification.query.filter_by(user_id=user.id, is_used=False).update({"is_used": True})
+        new_expires_at = datetime.utcnow() + timedelta(days=1)
+        new_token = EmailVerification.create_token(user.id, new_expires_at)
+        email_sent_successfully = send_verification_email(user, new_token)
+        if email_sent_successfully:
+            pipe = redis_client.pipeline()
+            pipe.set(attempts_key, attempts + 1)
+            pipe.set(last_attempt_ts_key, current_timestamp)
+            pipe.set(last_attempt_date_key, current_date_str)
+            pipe.expire(attempts_key, 86400 * 2)
+            pipe.expire(last_attempt_date_key, 86400 * 2)
+            pipe.expire(last_attempt_ts_key, 86400 * 2)
+            pipe.execute()
+            return {"message": "A new verification link has been sent to your email address."}, 200
+        else:
+            current_app.logger.error(f"Email sending itself failed for {email_address} during resend.")
+            return {"error_code": "EMAIL_SEND_FAILED", "message": "Failed to send verification email. Please try again later."}, 500
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Resend verification email controller error for {email_address}: {str(e)}")
+        return {"error_code": "INTERNAL_ERROR", "message": "An unexpected error occurred."}, 500

--- a/auth/email_utils.py
+++ b/auth/email_utils.py
@@ -286,7 +286,7 @@ def send_merchant_docs_submitted_to_admin(merchant_profile, admin_email_list=Non
 
 
     subject = f"Merchant Document Submission: {merchant_profile.business_name}"
-    admin_link = f"{frontend_url}//superadmin/merchant-management" 
+    admin_link = f"{frontend_url}/superadmin/merchant-management" 
 
     template = """
     <!DOCTYPE html>

--- a/controllers/merchant/brand_request_controller.py
+++ b/controllers/merchant/brand_request_controller.py
@@ -24,7 +24,7 @@ class MerchantBrandRequestController:
 
         br = BrandRequest(
             merchant_id=merchant.id,
-            name=data['name'],
+            name=data['brand_name'],
             status=BrandRequestStatus.PENDING
         )
         br.save()


### PR DESCRIPTION
- Added `/api/auth/verify-email/resend` endpoint with rate limiting to prevent abuse
- Modified login logic to deny access for users whose email is not verified
- Ensures users must verify their email before being allowed to sign in
- Validate email input via ResendVerificationSchema
- Return structured JSON for success, rate limit, and error cases