### PR TITLE
feat: Add SVG support to allowed file extensions for images

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ class Config:
     CLOUDINARY_CLOUD_NAME = os.getenv('CLOUDINARY_CLOUD_NAME')
     CLOUDINARY_API_KEY = os.getenv('CLOUDINARY_API_KEY')
     CLOUDINARY_API_SECRET = os.getenv('CLOUDINARY_API_SECRET')
-    ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf', 'doc', 'docx']
+    ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'svg' 'png', 'gif', 'webp', 'pdf', 'doc', 'docx']
 
     MAIL_SERVER = 'smtp.gmail.com'  # Replace with your SMTP server
     MAIL_PORT = 587  # Common ports: 587 (TLS), 465 (SSL)

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ class Config:
     CLOUDINARY_CLOUD_NAME = os.getenv('CLOUDINARY_CLOUD_NAME')
     CLOUDINARY_API_KEY = os.getenv('CLOUDINARY_API_KEY')
     CLOUDINARY_API_SECRET = os.getenv('CLOUDINARY_API_SECRET')
-    ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'svg' 'png', 'gif', 'webp', 'pdf', 'doc', 'docx']
+    ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'svg', 'png', 'gif', 'webp', 'pdf', 'doc', 'docx']
 
     MAIL_SERVER = 'smtp.gmail.com'  # Replace with your SMTP server
     MAIL_PORT = 587  # Common ports: 587 (TLS), 465 (SSL)

--- a/controllers/shop/shop_controller.py
+++ b/controllers/shop/shop_controller.py
@@ -10,7 +10,7 @@ import cloudinary.uploader
 from http import HTTPStatus
 
 # Allowed file extensions for image uploads
-ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'webp'}
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'svg', 'webp'}
 
 def allowed_file(filename):
     return '.' in filename and \

--- a/routes/merchant_routes.py
+++ b/routes/merchant_routes.py
@@ -36,7 +36,7 @@ from controllers.merchant.live_stream_controller import MerchantLiveStreamContro
 import logging
 
 
-ALLOWED_MEDIA_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'mp4', 'mov', 'avi'} 
+ALLOWED_MEDIA_EXTENSIONS = {'png', 'jpg', 'jpeg', 'svg', 'gif', 'webp', 'mp4', 'mov', 'avi'}
 
 def allowed_media_file(filename):
     """

--- a/routes/superadmin_routes.py
+++ b/routes/superadmin_routes.py
@@ -59,7 +59,7 @@ from controllers.superadmin import youtube_controller
 
 superadmin_bp = Blueprint('superadmin_bp', __name__)
 
-ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'webp'}  # removed extension type .svg and .gif 
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'svg', 'webp'}  # removed extension type .gif
 
 def allowed_file(filename):
     return '.' in filename and \
@@ -530,7 +530,7 @@ def upload_category_icon(cid):
         in: formData
         type: file
         required: true
-        description: "Icon image file to upload (png, jpg, jpeg, webp)."
+        description: "Icon image file to upload (png, jpg, jpeg, svg, webp)."
     responses:
       200:
         description: "Icon uploaded and category updated successfully."
@@ -1091,7 +1091,7 @@ def upload_brand_icon(bid):
         in: formData
         type: file
         required: true
-        description: "Icon image file to upload (png, jpg, jpeg, webp)."
+        description: "Icon image file to upload (png, jpg, jpeg, svg, webp)."
     responses:
       200:
         description: "Brand icon uploaded and updated successfully."

--- a/routes/upload_routes.py
+++ b/routes/upload_routes.py
@@ -9,7 +9,7 @@ import os
 upload_bp = Blueprint('upload', __name__)
 
 # Configure allowed file extensions
-ALLOWED_IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp'}
+ALLOWED_IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'svg', 'gif', 'webp'}
 ALLOWED_VIDEO_EXTENSIONS = {'mp4', 'mov', 'avi', 'mkv'}
 
 def allowed_file(filename, allowed_extensions):
@@ -76,8 +76,8 @@ def upload_image():
         
         # Validate file type
         if not allowed_file(file.filename, ALLOWED_IMAGE_EXTENSIONS):
-            return jsonify({'error': 'Invalid file type. Allowed types: PNG, JPG, JPEG, GIF, WebP'}), HTTPStatus.BAD_REQUEST
-        
+            return jsonify({'error': 'Invalid file type. Allowed types: PNG, JPG, JPEG, SVG, GIF, WebP'}), HTTPStatus.BAD_REQUEST
+
         # Get folder parameter
         folder = request.form.get('folder', 'products')
         


### PR DESCRIPTION
This pull request introduces updates to the allowed file extensions across multiple parts of the codebase, primarily to add support for the `svg` file format. The changes ensure consistency in handling file uploads and validations across different modules.

### Updates to Allowed File Extensions:

* **Configuration Updates:**
  - Added `svg` to the `ALLOWED_IMAGE_EXTENSIONS` list in the `Config` class in `config.py`.

* **Controller and Route Updates:**
  - Updated `ALLOWED_EXTENSIONS` in `controllers/shop/shop_controller.py` to include `svg`.
  - Updated `ALLOWED_MEDIA_EXTENSIONS` in `routes/merchant_routes.py` to include `svg`.
  - Updated `ALLOWED_EXTENSIONS` in `routes/superadmin_routes.py` to include `svg` and removed `gif`.

* **Documentation and Error Messages:**
  - Updated descriptions in `upload_category_icon` and `upload_brand_icon` functions in `routes/superadmin_routes.py` to reflect the inclusion of `svg` in allowed file types. [[1]](diffhunk://#diff-1d78507449fd8d601cc18be649a089e28570e248ac0375c037a835568c7287a9L533-R533) [[2]](diffhunk://#diff-1d78507449fd8d601cc18be649a089e28570e248ac0375c037a835568c7287a9L1094-R1094)
  - Updated the error message in `upload_image` in `routes/upload_routes.py` to include `svg` in the list of valid file types.